### PR TITLE
fix: dependency vulnerability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "league/flysystem": "^1.0.8",
         "psr/log": "^1.1",
         "symfony/config": "^3.4 || ^4.2",
-        "symfony/dependency-injection": "^3.4 || ^4.2",
+        "symfony/dependency-injection": "^3.4.26 || ^4.2.7",
         "symfony/event-dispatcher": "^3.4 || ^4.2",
         "symfony/http-client": "^3.4 || ^4.2",
         "symfony/http-foundation": "^3.4 || ^4.2",


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT

CVE-2019-10910 -  critical severity

Vulnerable versions: >= 4.0.0, < 4.1.12
Patched version: 4.1.12
In Symfony before 2.7.51, 2.8.x before 2.8.50, 3.x before 3.4.26, 4.x
before 4.1.12, and 4.2.x before 4.2.7, when service ids allow user
input, this could allow for SQL Injection and remote code execution.
This is related to symfony/dependency-injection.
