### PR TITLE
Remove useless remote-debugging-port=9222 chrome option

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -168,7 +168,6 @@ Create the `phpunit.xml` file as following:
         <env name="DOCUSIGN_ACCOUNT_ID" value="your-account-id" />
         <server name="PANTHER_WEB_SERVER_DIR" value="./features/public/" />
         <server name="PANTHER_NO_SANDBOX" value="1" />
-        <server name="PANTHER_CHROME_ARGUMENTS" value="--remote-debugging-port=9222" />
     </php>
 
     <testsuites>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,7 +18,6 @@
         <env name="DOCUSIGN_ACCOUNT_ID" value="1234567" />
         <server name="PANTHER_WEB_SERVER_DIR" value="./features/public/" />
         <server name="PANTHER_NO_SANDBOX" value="1" />
-        <server name="PANTHER_CHROME_ARGUMENTS" value="--remote-debugging-port=9222" />
     </php>
 
     <testsuites>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT