### PR TITLE
fix:  empty the webhookParameters var after sending an envelope

### DIFF
--- a/src/EnvelopeBuilder.php
+++ b/src/EnvelopeBuilder.php
@@ -230,6 +230,7 @@ final class EnvelopeBuilder implements EnvelopeBuilderInterface
         $this->apiClient = null;
         $this->envelopesApi = null;
         $this->envelopeId = null;
+        $this->webhookParameters = [];
     }
 
     public function getEnvelopesApi(): ?EnvelopesApi


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

When sending a batch of documents, the token of the previous transaction is kept to regenerate the new validation token which prevents validating the docusign callback after signature