### PR TITLE
Update LocalFilesystemAdapter definition arguments

### DIFF
--- a/src/Adapter/Builder/LocalAdapterDefinitionBuilder.php
+++ b/src/Adapter/Builder/LocalAdapterDefinitionBuilder.php
@@ -62,7 +62,10 @@ class LocalAdapterDefinitionBuilder extends AbstractAdapterDefinitionBuilder
         if (class_exists(LocalFilesystemAdapter::class)) {
             $definition->setClass(LocalFilesystemAdapter::class);
             $definition->setArgument(0, $options['directory']);
-            $definition->setArgument(1, PortableVisibilityConverter::fromArray($options['permissions']));
+            $visibilityConverter = new Definition(PortableVisibilityConverter::class);
+            $visibilityConverter->setFactory([PortableVisibilityConverter::class, 'fromArray']);
+            $visibilityConverter->addArgument($options['permissions']);
+            $definition->setArgument(1, $visibilityConverter);
             $definition->setArgument(2, $options['lock']);
             $definition->setArgument(3, $options['skip_links'] ? LocalFilesystemAdapter::SKIP_LINKS : LocalFilesystemAdapter::DISALLOW_LINKS);
         } else {


### PR DESCRIPTION
The Flysystem v2 LocalFilesystemAdapter arguments have a different ordering than the v1 Local class.

<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | ?
| Fixed tickets | #121
| License       | MIT

<!-- Bug fixes should be based against the lowest stable version branch, master is for new features only -->

@GregoireHebert
