### PR TITLE
chore: fix deprecations in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -58,10 +58,10 @@ jobs:
 
       - name: Get Composer Cache Directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
@@ -142,7 +142,7 @@ jobs:
 
       - name: Upload coverage results to Codecov
         if: matrix.coverage != ''
-        uses: codecov/codecov-action@v1.0.3
+        uses: codecov/codecov-action@v3
         with:
           name: phpunit-php${{ matrix.php }}
           flags: phpunit


### PR DESCRIPTION
Will fix warnings in ci
https://github.com/GregoireHebert/docusign-bundle/actions/runs/3921430615

checkout@v1 => v3
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/cache@v1. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

set-output
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Codecov (needs testing)
https://github.com/codecov/codecov-action#%EF%B8%8F--deprecation-of-v1